### PR TITLE
XML changes and Load Balancing

### DIFF
--- a/cesm_tools.py
+++ b/cesm_tools.py
@@ -162,7 +162,7 @@ class RegionalCaseGen:
         date_range,
         bathymetry_path,
         cyclic_x=False,
-        processors_per_node=128,
+        cores_per_node=128,
         ideal_number_of_points_per_core_ceiling = 800,
 
     ):
@@ -226,16 +226,16 @@ class RegionalCaseGen:
         # Load Balancing Math
         total_number_of_points = nx * ny
         nodes=1
-        pts_per_processor = total_number_of_points/ float(processors_per_node)
+        pts_per_processor = total_number_of_points/ float(cores_per_node)
         while pts_per_processor > ideal_number_of_points_per_core_ceiling:
             nodes = nodes+1
-            pts_per_processor = total_number_of_points / float(processors_per_node * nodes)
+            pts_per_processor = total_number_of_points / float(cores_per_node * nodes)
             
         
         # Avoid one node for all other components in ocean_only mode
-        self.xmlchange(CESMPath, "ROOTPE_OCN", str(processors_per_node))
+        self.xmlchange(CESMPath, "ROOTPE_OCN", str(cores_per_node))
         # Set the number of processors
-        self.xmlchange(CESMPath, "NTASKS_OCN", nodes*processors_per_node)
+        self.xmlchange(CESMPath, "NTASKS_OCN", nodes*cores_per_node)
 
 
         # Make xml changes

--- a/cesm_tools.py
+++ b/cesm_tools.py
@@ -227,9 +227,10 @@ class RegionalCaseGen:
         total_number_of_points = nx * ny
         nodes=1
         pts_per_processor = total_number_of_points/ float(processors_per_node)
-        while not pts_per_processor < ideal_number_of_points_per_core_ceiling:
-            pts_per_processor = total_number_of_points / float(processors_per_node * nodes)
+        while pts_per_processor > ideal_number_of_points_per_core_ceiling:
             nodes = nodes+1
+            pts_per_processor = total_number_of_points / float(processors_per_node * nodes)
+            
         
         # Avoid one node for all other components in ocean_only mode
         self.xmlchange(CESMPath, "ROOTPE_OCN", str(processors_per_node))

--- a/cesm_tools.py
+++ b/cesm_tools.py
@@ -162,6 +162,8 @@ class RegionalCaseGen:
         date_range,
         bathymetry_path,
         cyclic_x=False,
+        processors_per_node=128,
+        ideal_number_of_points_per_core_ceiling = 800,
 
     ):
         """
@@ -221,6 +223,18 @@ class RegionalCaseGen:
             cyclic_x=cyclic_x,
         )
 
+        # Load Balancing Math
+        total_number_of_points = nx * ny
+        nodes=1
+        pts_per_processor = total_number_of_points/ float(processors_per_node)
+        while not pts_per_processor < ideal_number_of_points_per_core_ceiling:
+            pts_per_processor = total_number_of_points / float(processors_per_node * nodes)
+            nodes = nodes+1
+        
+        # Avoid one node for all other components in ocean_only mode
+        self.xmlchange(CESMPath, "ROOTPE_OCN", str(processors_per_node))
+        # Set the number of processors
+        self.xmlchange(CESMPath, "NTASKS_OCN", nodes*processors_per_node)
 
 
         # Make xml changes

--- a/cesm_tools.py
+++ b/cesm_tools.py
@@ -7,7 +7,7 @@ import os
 import subprocess
 from .utils import setup_logger
 
-rcg_logger = setup_logger(__name__) # this should be replaced by a workflow utils
+rcg_logger = setup_logger(__name__)  # this should be replaced by a workflow utils
 
 
 class RegionalCaseGen:
@@ -163,8 +163,7 @@ class RegionalCaseGen:
         bathymetry_path,
         cyclic_x=False,
         cores_per_node=128,
-        ideal_number_of_points_per_core_ceiling = 800,
-
+        ideal_number_of_points_per_core_ceiling=800,
     ):
         """
         Given a regional-mom6 experiment object and a path to the CESM folder, this function makes all of the changes to the CESM configuration to get it to run with the regional configuration.
@@ -191,7 +190,11 @@ class RegionalCaseGen:
 
         # Remove references to MOM_layout in input.nml, as processor layouts are handled by CESM
         rcg_logger.info("Add MOM_override to parameter_filename in input.nml")
-        self.edit_input_nml_for_CESM(CESMPath, condition_strings=["MOM_layout", "parameter_filename"], new_string="parameter_filename = 'MOM_input', 'MOM_override'")
+        self.edit_input_nml_for_CESM(
+            CESMPath,
+            condition_strings=["MOM_layout", "parameter_filename"],
+            new_string="parameter_filename = 'MOM_input', 'MOM_override'",
+        )
 
         # Move all of the forcing files out of the forcing directory to the main inputdir
         rcg_logger.info(
@@ -225,18 +228,16 @@ class RegionalCaseGen:
 
         # Load Balancing Math
         total_number_of_points = nx * ny
-        nodes=1
-        pts_per_core = total_number_of_points/ float(cores_per_node)
+        nodes = 1
+        pts_per_core = total_number_of_points / float(cores_per_node)
         while pts_per_core > ideal_number_of_points_per_core_ceiling:
-            nodes = nodes+1
+            nodes = nodes + 1
             pts_per_core = total_number_of_points / float(cores_per_node * nodes)
-            
-        
+
         # Avoid one node for all other components in ocean_only mode
         self.xmlchange(CESMPath, "ROOTPE_OCN", str(cores_per_node))
         # Set the number of processors
-        self.xmlchange(CESMPath, "NTASKS_OCN", nodes*cores_per_node)
-
+        self.xmlchange(CESMPath, "NTASKS_OCN", nodes * cores_per_node)
 
         # Make xml changes
         self.xmlchange(CESMPath, "OCN_NX", str(nx))
@@ -263,8 +264,12 @@ class RegionalCaseGen:
 
         return
 
-
-    def edit_input_nml_for_CESM(self, CESMPath, condition_strings: list = ["MOM_layout", "parameter_filename"], new_string: str = "parameter_filename = 'MOM_input', 'MOM_override'"):
+    def edit_input_nml_for_CESM(
+        self,
+        CESMPath,
+        condition_strings: list = ["MOM_layout", "parameter_filename"],
+        new_string: str = "parameter_filename = 'MOM_input', 'MOM_override'",
+    ):
         """
         Remove reference to condition_strings in input.nml and adds the new_strong. The only reason to take this out of the setup_cesm function is to remove direct file changes from the main function.
         Parameters
@@ -276,14 +281,16 @@ class RegionalCaseGen:
         new_string : str, optional
             The new string to replace that line with, by default "parameter_filename = 'MOM_input', 'MOM_override'"
         """
-        rcg_logger.info("Removing reference to MOM_layout in input.nml and add MOM_override to parameter_filename in input.nml")
+        rcg_logger.info(
+            "Removing reference to MOM_layout in input.nml and add MOM_override to parameter_filename in input.nml"
+        )
         with open(CESMPath / "SourceMods/src.mom/input.nml", "r") as f:
             lines = f.readlines()
             f.close()
         rcg_logger.info("")
         with open(CESMPath / "SourceMods/src.mom/input.nml", "w") as f:
             for i in range(len(lines)):
-                if all(cond in lines[i]  for cond in condition_strings):
+                if all(cond in lines[i] for cond in condition_strings):
                     rcg_logger.info(f"Modifying line: {lines[i].strip()}")
                     lines[i] = new_string
             f.writelines(lines)
@@ -310,4 +317,3 @@ class RegionalCaseGen:
             shell=True,
             cwd=str(CESM_path),
         )
-

--- a/cesm_tools.py
+++ b/cesm_tools.py
@@ -7,7 +7,7 @@ import os
 import subprocess
 import logging
 
-rcg_logger = logging.Logger(__name__) # this should be replaced by a workflow utils
+rcg_logger = logging.Logger(__name__)  # this should be replaced by a workflow utils
 
 
 class RegionalCaseGen:
@@ -163,8 +163,7 @@ class RegionalCaseGen:
         bathymetry_path,
         cyclic_x=False,
         cores_per_node=128,
-        ideal_number_of_points_per_core_ceiling = 800,
-
+        ideal_number_of_points_per_core_ceiling=800,
     ):
         """
         Given a regional-mom6 experiment object and a path to the CESM folder, this function makes all of the changes to the CESM configuration to get it to run with the regional configuration.
@@ -191,7 +190,11 @@ class RegionalCaseGen:
 
         # Remove references to MOM_layout in input.nml, as processor layouts are handled by CESM
         rcg_logger.info("Add MOM_override to parameter_filename in input.nml")
-        self.edit_input_nml_for_CESM(CESMPath, condition_strings=["MOM_layout", "parameter_filename"], new_string="parameter_filename = 'MOM_input', 'MOM_override'")
+        self.edit_input_nml_for_CESM(
+            CESMPath,
+            condition_strings=["MOM_layout", "parameter_filename"],
+            new_string="parameter_filename = 'MOM_input', 'MOM_override'",
+        )
 
         # Move all of the forcing files out of the forcing directory to the main inputdir
         rcg_logger.info(
@@ -225,18 +228,16 @@ class RegionalCaseGen:
 
         # Load Balancing Math
         total_number_of_points = nx * ny
-        nodes=1
-        pts_per_processor = total_number_of_points/ float(cores_per_node)
+        nodes = 1
+        pts_per_processor = total_number_of_points / float(cores_per_node)
         while pts_per_processor > ideal_number_of_points_per_core_ceiling:
-            nodes = nodes+1
+            nodes = nodes + 1
             pts_per_processor = total_number_of_points / float(cores_per_node * nodes)
-            
-        
+
         # Avoid one node for all other components in ocean_only mode
         self.xmlchange(CESMPath, "ROOTPE_OCN", str(cores_per_node))
         # Set the number of processors
-        self.xmlchange(CESMPath, "NTASKS_OCN", nodes*cores_per_node)
-
+        self.xmlchange(CESMPath, "NTASKS_OCN", nodes * cores_per_node)
 
         # Make xml changes
         self.xmlchange(CESMPath, "OCN_NX", str(nx))
@@ -265,8 +266,12 @@ class RegionalCaseGen:
 
         return
 
-
-    def edit_input_nml_for_CESM(self, CESMPath, condition_strings: list = ["MOM_layout", "parameter_filename"], new_string: str = "parameter_filename = 'MOM_input', 'MOM_override'"):
+    def edit_input_nml_for_CESM(
+        self,
+        CESMPath,
+        condition_strings: list = ["MOM_layout", "parameter_filename"],
+        new_string: str = "parameter_filename = 'MOM_input', 'MOM_override'",
+    ):
         """
         Remove reference to condition_strings in input.nml and adds the new_strong. The only reason to take this out of the setup_cesm function is to remove direct file changes from the main function.
         Parameters
@@ -278,14 +283,16 @@ class RegionalCaseGen:
         new_string : str, optional
             The new string to replace that line with, by default "parameter_filename = 'MOM_input', 'MOM_override'"
         """
-        rcg_logger.info("Removing reference to MOM_layout in input.nml and add MOM_override to parameter_filename in input.nml")
+        rcg_logger.info(
+            "Removing reference to MOM_layout in input.nml and add MOM_override to parameter_filename in input.nml"
+        )
         with open(CESMPath / "SourceMods/src.mom/input.nml", "r") as f:
             lines = f.readlines()
             f.close()
         rcg_logger.info("")
         with open(CESMPath / "SourceMods/src.mom/input.nml", "w") as f:
             for i in range(len(lines)):
-                if all(cond in lines[i]  for cond in condition_strings):
+                if all(cond in lines[i] for cond in condition_strings):
                     rcg_logger.info(f"Modifying line: {lines[i].strip()}")
                     lines[i] = new_string
             f.writelines(lines)
@@ -312,4 +319,3 @@ class RegionalCaseGen:
             shell=True,
             cwd=str(CESM_path),
         )
-

--- a/cesm_tools.py
+++ b/cesm_tools.py
@@ -7,7 +7,7 @@ import os
 import subprocess
 import logging
 
-rcg_logger = logging.Logger(__name__)  # this should be replaced by a workflow utils
+rcg_logger = logging.Logger(__name__) # this should be replaced by a workflow utils
 
 
 class RegionalCaseGen:
@@ -163,7 +163,8 @@ class RegionalCaseGen:
         bathymetry_path,
         cyclic_x=False,
         cores_per_node=128,
-        ideal_number_of_points_per_core_ceiling=800,
+        ideal_number_of_points_per_core_ceiling = 800,
+
     ):
         """
         Given a regional-mom6 experiment object and a path to the CESM folder, this function makes all of the changes to the CESM configuration to get it to run with the regional configuration.
@@ -190,11 +191,7 @@ class RegionalCaseGen:
 
         # Remove references to MOM_layout in input.nml, as processor layouts are handled by CESM
         rcg_logger.info("Add MOM_override to parameter_filename in input.nml")
-        self.edit_input_nml_for_CESM(
-            CESMPath,
-            condition_strings=["MOM_layout", "parameter_filename"],
-            new_string="parameter_filename = 'MOM_input', 'MOM_override'",
-        )
+        self.edit_input_nml_for_CESM(CESMPath, condition_strings=["MOM_layout", "parameter_filename"], new_string="parameter_filename = 'MOM_input', 'MOM_override'")
 
         # Move all of the forcing files out of the forcing directory to the main inputdir
         rcg_logger.info(
@@ -228,16 +225,18 @@ class RegionalCaseGen:
 
         # Load Balancing Math
         total_number_of_points = nx * ny
-        nodes = 1
-        pts_per_processor = total_number_of_points / float(cores_per_node)
+        nodes=1
+        pts_per_processor = total_number_of_points/ float(cores_per_node)
         while pts_per_processor > ideal_number_of_points_per_core_ceiling:
-            nodes = nodes + 1
+            nodes = nodes+1
             pts_per_processor = total_number_of_points / float(cores_per_node * nodes)
-
+            
+        
         # Avoid one node for all other components in ocean_only mode
         self.xmlchange(CESMPath, "ROOTPE_OCN", str(cores_per_node))
         # Set the number of processors
-        self.xmlchange(CESMPath, "NTASKS_OCN", nodes * cores_per_node)
+        self.xmlchange(CESMPath, "NTASKS_OCN", nodes*cores_per_node)
+
 
         # Make xml changes
         self.xmlchange(CESMPath, "OCN_NX", str(nx))
@@ -266,12 +265,8 @@ class RegionalCaseGen:
 
         return
 
-    def edit_input_nml_for_CESM(
-        self,
-        CESMPath,
-        condition_strings: list = ["MOM_layout", "parameter_filename"],
-        new_string: str = "parameter_filename = 'MOM_input', 'MOM_override'",
-    ):
+
+    def edit_input_nml_for_CESM(self, CESMPath, condition_strings: list = ["MOM_layout", "parameter_filename"], new_string: str = "parameter_filename = 'MOM_input', 'MOM_override'"):
         """
         Remove reference to condition_strings in input.nml and adds the new_strong. The only reason to take this out of the setup_cesm function is to remove direct file changes from the main function.
         Parameters
@@ -283,16 +278,14 @@ class RegionalCaseGen:
         new_string : str, optional
             The new string to replace that line with, by default "parameter_filename = 'MOM_input', 'MOM_override'"
         """
-        rcg_logger.info(
-            "Removing reference to MOM_layout in input.nml and add MOM_override to parameter_filename in input.nml"
-        )
+        rcg_logger.info("Removing reference to MOM_layout in input.nml and add MOM_override to parameter_filename in input.nml")
         with open(CESMPath / "SourceMods/src.mom/input.nml", "r") as f:
             lines = f.readlines()
             f.close()
         rcg_logger.info("")
         with open(CESMPath / "SourceMods/src.mom/input.nml", "w") as f:
             for i in range(len(lines)):
-                if all(cond in lines[i] for cond in condition_strings):
+                if all(cond in lines[i]  for cond in condition_strings):
                     rcg_logger.info(f"Modifying line: {lines[i].strip()}")
                     lines[i] = new_string
             f.writelines(lines)
@@ -319,3 +312,4 @@ class RegionalCaseGen:
             shell=True,
             cwd=str(CESM_path),
         )
+

--- a/cesm_tools.py
+++ b/cesm_tools.py
@@ -7,8 +7,6 @@ import os
 import subprocess
 import logging
 
-rcg_logger = logging.Logger(__name__) # this should be replaced by a workflow utils
-import logging
 
 rcg_logger = logging.Logger(__name__) # this should be replaced by a workflow utils
 

--- a/cesm_tools.py
+++ b/cesm_tools.py
@@ -7,7 +7,6 @@ import os
 import subprocess
 import logging
 
-
 rcg_logger = logging.Logger(__name__) # this should be replaced by a workflow utils
 
 

--- a/cesm_tools.py
+++ b/cesm_tools.py
@@ -245,7 +245,7 @@ class RegionalCaseGen:
         self.xmlchange(CESMPath, "OCN_DOMAIN_MESH", str(mom_input_dir / "esmf_mesh.nc"))
         self.xmlchange(CESMPath, "ICE_DOMAIN_MESH", str(mom_input_dir / "esmf_mesh.nc"))
         self.xmlchange(CESMPath, "MASK_MESH", str(mom_input_dir / "esmf_mesh.nc"))
-        self.xmlchange(CESMPath, "OCN_GRID", "RegionalCaseGen")
+        self.xmlchange(CESMPath, "OCN_GRID", "RegCaseGen")
         self.xmlchange(CESMPath, "RUN_REFDATE", str(date_range[0].strftime("%Y-%m-%d")))
         self.xmlchange(
             CESMPath, "RUN_STARTDATE", str(date_range[0].strftime("%Y-%m-%d"))

--- a/cesm_tools.py
+++ b/cesm_tools.py
@@ -5,9 +5,9 @@ from datetime import datetime
 import shutil
 import os
 import subprocess
-import logging
+from .utils import setup_logger
 
-rcg_logger = logging.Logger(__name__) # this should be replaced by a workflow utils
+rcg_logger = setup_logger(__name__) # this should be replaced by a workflow utils
 
 
 class RegionalCaseGen:

--- a/cesm_tools.py
+++ b/cesm_tools.py
@@ -163,6 +163,8 @@ class RegionalCaseGen:
         date_range,
         bathymetry_path,
         cyclic_x=False,
+        processors_per_node=128,
+        ideal_number_of_points_per_core_ceiling = 800,
     ):
         """
         Given a regional-mom6 experiment object and a path to the CESM folder, this function makes all of the changes to the CESM configuration to get it to run with the regional configuration.
@@ -235,6 +237,22 @@ class RegionalCaseGen:
             title="Regional MOM6 grid",
             cyclic_x=cyclic_x,
         )
+
+        # Load Balancing Math
+        total_number_of_points = nx * ny
+        nodes=1
+        pts_per_processor = total_number_of_points/ float(processors_per_node)
+        while not pts_per_processor < ideal_number_of_points_per_core_ceiling:
+            pts_per_processor = total_number_of_points / float(processors_per_node * nodes)
+            nodes = nodes+1
+        
+
+        # Avoid one node for all other components in ocean_only mode
+        self.xmlchange(CESMPath, "ROOTPE_OCN", str(processors_per_node))
+
+        # Set the number of processors
+        self.xmlchange(CESMPath, "NTASKS_OCN", nodes*processors_per_node)
+
 
         # Make xml changes
         self.xmlchange(CESMPath, "OCN_NX", str(nx))

--- a/cesm_tools.py
+++ b/cesm_tools.py
@@ -162,8 +162,7 @@ class RegionalCaseGen:
         date_range,
         bathymetry_path,
         cyclic_x=False,
-        processors_per_node=128,
-        ideal_number_of_points_per_core_ceiling = 800,
+
     ):
         """
         Given a regional-mom6 experiment object and a path to the CESM folder, this function makes all of the changes to the CESM configuration to get it to run with the regional configuration.

--- a/cesm_tools.py
+++ b/cesm_tools.py
@@ -226,10 +226,10 @@ class RegionalCaseGen:
         # Load Balancing Math
         total_number_of_points = nx * ny
         nodes=1
-        pts_per_processor = total_number_of_points/ float(cores_per_node)
-        while pts_per_processor > ideal_number_of_points_per_core_ceiling:
+        pts_per_core = total_number_of_points/ float(cores_per_node)
+        while pts_per_core > ideal_number_of_points_per_core_ceiling:
             nodes = nodes+1
-            pts_per_processor = total_number_of_points / float(cores_per_node * nodes)
+            pts_per_core = total_number_of_points / float(cores_per_node * nodes)
             
         
         # Avoid one node for all other components in ocean_only mode

--- a/cesm_tools.py
+++ b/cesm_tools.py
@@ -245,9 +245,7 @@ class RegionalCaseGen:
         self.xmlchange(CESMPath, "OCN_DOMAIN_MESH", str(mom_input_dir / "esmf_mesh.nc"))
         self.xmlchange(CESMPath, "ICE_DOMAIN_MESH", str(mom_input_dir / "esmf_mesh.nc"))
         self.xmlchange(CESMPath, "MASK_MESH", str(mom_input_dir / "esmf_mesh.nc"))
-        self.xmlchange(CESMPath, "MASK_GRID", str(mom_input_dir / "esmf_mesh.nc"))
-        self.xmlchange(CESMPath, "OCN_GRID", str(mom_input_dir / "esmf_mesh.nc"))
-        self.xmlchange(CESMPath, "ICE_GRID", str(mom_input_dir / "esmf_mesh.nc"))
+        self.xmlchange(CESMPath, "OCN_GRID", "RegionalCaseGen")
         self.xmlchange(CESMPath, "RUN_REFDATE", str(date_range[0].strftime("%Y-%m-%d")))
         self.xmlchange(
             CESMPath, "RUN_STARTDATE", str(date_range[0].strftime("%Y-%m-%d"))

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,21 @@
+import os
+import logging
+import sys
+
+def setup_logger(name):
+    logger = logging.getLogger(name)
+    logger.setLevel(logging.INFO)
+    if not logger.hasHandlers():
+        # Create a handler to print to stdout (Jupyter captures stdout)
+        handler = logging.StreamHandler(sys.stdout)
+        handler.setLevel(logging.INFO)
+
+        # Create a formatter (optional)
+        formatter = logging.Formatter(
+            "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        )
+        handler.setFormatter(formatter)
+
+        # Add the handler to the logger
+        logger.addHandler(handler)
+    return logger

--- a/utils.py
+++ b/utils.py
@@ -1,6 +1,6 @@
-import os
 import logging
 import sys
+
 
 def setup_logger(name):
     logger = logging.getLogger(name)


### PR DESCRIPTION
Fixes #7 


- [x] This change adds two xml changes to the CESM setup related to load balancing. ROOTPE_OCN=128 to give all other parts of the model a node, and NTASKS_OCN based on making sure there are less than 800 points per core, and we use every core on a node (i.e. multiple of 128)
- [ ] **REMOVED - YAGNI**: Will also include development on how to include shared code from CRR, RM6, and RCG. I'm leaning toward a subpackage called utils ....but then we have three levels of submodules🙈